### PR TITLE
Fixed crash of script when entering the output of the vulnerability scan

### DIFF
--- a/nmapy.py
+++ b/nmapy.py
@@ -62,6 +62,7 @@ content = []
 
 print("Scanning the network")
 
+os.system("ip a")
 while True:
     ip = input("Enter the ip address of the network you would like to scan: ")
 

--- a/vulnerability_scan.py
+++ b/vulnerability_scan.py
@@ -39,6 +39,7 @@ def vulnerability_scan(file_name):
             new_folder = (
                 os.getcwd() + "/scanned_hosts/" + file_name.split("_hosts.txt")[0] + "/"
             )
+            os.mkdir(new_folder)
             os.popen("touch " + new_folder + ip + ".txt")
             with open(new_folder + ip + ".txt", "w") as file:
                 for i in response:


### PR DESCRIPTION
The vulnerability_scan.py script always crashed when trying to enter the output of the vulnerability scan in a file since the folder in which the file would be created, wasn't made.